### PR TITLE
stop using argument parsing everywhere to make the code easier to test

### DIFF
--- a/cmd/example/configs/application.properties
+++ b/cmd/example/configs/application.properties
@@ -1,0 +1,7 @@
+http.port=12345
+log.level=debug
+tracing.enabled=false
+healthcheck.enabled=true
+prometheus.enabled=true
+pprof.enabled=true
+pprof.port=8082

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	gaz "github.com/skysoft-atm/gorillaz"
+)
+
+func main() {
+	gaz.Init(".", nil)
+
+	// write your application code here
+
+	gaz.SetReady(true)
+	gaz.SetLive(true)
+	select {}
+}

--- a/config.go
+++ b/config.go
@@ -25,7 +25,6 @@ func parseProperties(reader io.Reader) map[string]string {
 			m[split[0]] = split[1]
 		}
 	}
-
 	return m
 }
 

--- a/config.go
+++ b/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+//TODO: there is a lot of code here. Is all of this really necessary?
+
 func getPropertiesKeys(scanner bufio.Scanner) map[string]string {
 	m := make(map[string]string)
 
@@ -91,16 +93,16 @@ func parseConfiguration(context map[string]interface{}) {
 }
 
 func GetConfigPath(context map[string]interface{}) string {
-	var conf string
 	if v, contains := context["conf"]; contains {
-		conf = v.(string)
-	} else {
-		if !isFlagDefined("conf") {
-			flag.StringVar(&conf, "conf", "configs", "config file. default: configs")
-		} else {
-			conf = getFlagValue("conf")
-		}
+		conf := v.(string)
+		return conf
 	}
+	if isFlagDefined("conf") {
+		return getFlagValue("conf")
+	}
+	var conf string
+	//TODO : where is flag.Parse called?
+	flag.StringVar(&conf, "conf", "configs", "config file. default: configs")
 	return conf
 }
 

--- a/core.go
+++ b/core.go
@@ -2,6 +2,8 @@ package gorillaz
 
 import "runtime"
 
+//TODO: do we need this? Can't we directly use  runtime.NumCPU()?
+
 var cores = runtime.NumCPU()
 
 // Cores returns the num of CPU

--- a/elastic.go
+++ b/elastic.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
 )
 
 // UploadElasticSearchTemplate uploads the template file from configFolder/template to Elasticsearch
@@ -13,7 +12,7 @@ func UploadElasticSearchTemplate(hostname string, client *http.Client, template 
 	//TODO: GetConfigPath of nil probably panic since we try to read a nil map
 	configPath := GetConfigPath(nil)
 
-	templateFile := path.Join(configPath, "/", template)
+	templateFile := configPath + "/" + template
 
 	fileContent, err := ioutil.ReadFile(templateFile)
 	if err != nil {
@@ -23,7 +22,7 @@ func UploadElasticSearchTemplate(hostname string, client *http.Client, template 
 
 	Sugar.Infof("Going to upload template file: %s", templateFile)
 
-	uri := path.Join(hostname + "/_template/" + template)
+	uri := hostname + "/_template/" + template
 	body := bytes.NewReader(fileContent)
 	req, err := http.NewRequest(http.MethodPut, uri, body)
 

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -28,11 +28,13 @@ func InitHealthcheck(serverPort int) {
 
 // SetReady returns the actual internal state to precise if the given microservice is ready
 func SetReady(status bool) {
+	//TODO: there might be some concurrency issues here, but I'm not sure how bad it can behave
 	isReady = status
 }
 
 // SetLive returns the actual internal state to precise if the given microservice is live
 func SetLive(status bool) {
+	//TODO: there might be some concurrency issues here, but I'm not sure how bad it can behave
 	isLive = status
 }
 

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -1,45 +1,42 @@
 package gorillaz
 
 import (
-	"fmt"
 	"net/http"
+	"sync/atomic"
 
-	"github.com/apex/log"
 	"github.com/gorilla/mux"
 )
 
-var isReady = false
-var isLive = false
+// use int32 because sync.atomic package doesn't support boolean out of the box
+var isReady int32
+var isLive int32
 
-// InitHealthcheck starts two http endpoints (GET) for liveness and readiness probes in k8s
-func InitHealthcheck(serverPort int) {
-	r := mux.NewRouter()
-	r.HandleFunc("/ready", ready).Methods("GET")
-	r.HandleFunc("/live", live).Methods("GET")
-
-	go func() {
-		err := http.ListenAndServe(fmt.Sprintf(":%d", serverPort), r)
-		if err != nil {
-			log.Fatalf("Error while exposing health port: %v", err)
-			panic(err)
-		}
-	}()
+// InitHealthcheck registers /live and /ready (GET) for liveness and readiness probes in k8s
+func InitHealthcheck(router *mux.Router) {
+	router.HandleFunc("/ready", ready).Methods("GET")
+	router.HandleFunc("/live", live).Methods("GET")
 }
 
 // SetReady returns the actual internal state to precise if the given microservice is ready
 func SetReady(status bool) {
-	//TODO: there might be some concurrency issues here, but I'm not sure how bad it can behave
-	isReady = status
+	var statusInt int32
+	if status {
+		statusInt = 1
+	}
+	atomic.StoreInt32(&isReady, statusInt)
 }
 
 // SetLive returns the actual internal state to precise if the given microservice is live
 func SetLive(status bool) {
-	//TODO: there might be some concurrency issues here, but I'm not sure how bad it can behave
-	isLive = status
+	var statusInt int32
+	if status {
+		statusInt = 1
+	}
+	atomic.StoreInt32(&isLive, statusInt)
 }
 
 func ready(w http.ResponseWriter, _ *http.Request) {
-	if isReady {
+	if atomic.LoadInt32(&isReady) == 1 {
 		w.WriteHeader(http.StatusOK)
 	} else {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -47,7 +44,7 @@ func ready(w http.ResponseWriter, _ *http.Request) {
 }
 
 func live(w http.ResponseWriter, _ *http.Request) {
-	if isLive {
+	if atomic.LoadInt32(&isLive) == 1 {
 		w.WriteHeader(http.StatusOK)
 	} else {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,0 +1,54 @@
+package gorillaz
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+//TestHealth tests the creation of a prometheus endpoint and the given path
+func TestHealth(t *testing.T) {
+	SetupLogger()
+	router := mux.NewRouter()
+	InitHealthcheck(router)
+
+	port, shutdown := setupServerHTTP(router)
+	defer shutdown()
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+
+	okStatus := http.StatusOK
+	koStatus := http.StatusServiceUnavailable
+
+	check(t, "ready and live are unset", baseURL+"/ready", koStatus)
+	check(t, "ready and live are unset", baseURL+"/live", koStatus)
+
+	SetReady(true)
+	check(t, "ready is set", baseURL+"/ready", okStatus)
+	check(t, "ready is set", baseURL+"/live", koStatus)
+
+	SetLive(true)
+	check(t, "ready and live are set", baseURL+"/ready", okStatus)
+	check(t, "ready and live are set", baseURL+"/live", okStatus)
+
+	SetReady(false)
+	check(t, "ready is set to false", baseURL+"/ready", koStatus)
+	check(t, "ready is set to false", baseURL+"/live", okStatus)
+
+	SetLive(false)
+	check(t, "ready and live are set to false", baseURL+"/ready", koStatus)
+	check(t, "ready and live are set to false", baseURL+"/live", koStatus)
+}
+
+func check(t *testing.T, scenario, url string, expectedStatus int) {
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf("%s: cannot query %s, %+v", scenario, url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != expectedStatus {
+		t.Errorf("%s: expected status %d but got %d", scenario, expectedStatus, resp.StatusCode)
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,26 @@
+package gorillaz
+
+import (
+	"net"
+	"net/http/httptest"
+
+	"github.com/gorilla/mux"
+)
+
+// mandatory
+func SetupLogger() {
+	InitLogs("info")
+}
+
+// setupServerHttp creates a HTTP server on a random free TCP port
+// it returns the TCP port and a function that shutdowns the server
+func setupServerHTTP(r *mux.Router) (port int, shutdown func()) {
+	srv := httptest.NewServer(r)
+	port = srv.Listener.Addr().(*net.TCPAddr).Port
+	shutdown = func() {
+		srv.Close()
+	}
+	return
+}
+
+//func checkResponse(t *testing.T, resp *http.Response, checks func(test))

--- a/kafka.go
+++ b/kafka.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Shopify/sarama"
-	"github.com/bsm/sarama-cluster"
+	cluster "github.com/bsm/sarama-cluster"
 	"github.com/opentracing/opentracing-go"
 	"github.com/reactivex/rxgo"
 	"github.com/reactivex/rxgo/handlers"
@@ -46,9 +46,8 @@ func KafkaService(bootstrapServers string, source string, sink string, groupID s
 
 	if err != nil {
 		return nil, nil, err
-	} else {
-		return observable, observer, nil
 	}
+	return observable, observer, nil
 }
 
 // KafkaProducer returns an observer of KafkaEnvelope.
@@ -82,9 +81,6 @@ func KafkaConsumer(bootstrapServers string, source string, groupID string) rxgo.
 	observable := rxgo.FromChannel(request)
 
 	go func() {
-		if bootstrapServers == "" {
-			bootstrapServers = viper.GetString("kafka.bootstrapservers")
-		}
 
 		Log.Info("Creation of a new Kafka consumer",
 			zap.String("server", bootstrapServers),

--- a/log.go
+++ b/log.go
@@ -3,7 +3,6 @@ package gorillaz
 import (
 	"log"
 
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -15,14 +14,13 @@ var Log *zap.Logger
 var Sugar *zap.SugaredLogger
 
 // InitLogs initializes the Sugar (*zap.SugaredLogger) and Log (*zap.Logger) elements
-func InitLogs() {
+func InitLogs(logLevel string) {
 	config := zap.NewProductionConfig()
 
 	err := config.EncoderConfig.EncodeTime.UnmarshalText([]byte("iso8601"))
 	if err != nil {
 		log.Fatalf("error trying to define encoding %v", err)
 	}
-	logLevel := viper.GetString("log.level")
 
 	config.Level = zap.NewAtomicLevelAt(zapcore.PanicLevel)
 	if logLevel == "debug" {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package gorillaz
 import (
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -16,6 +17,7 @@ func Init(root string, context map[string]interface{}) {
 		return
 	}
 
+	//TODO: what's this for? We should be careful with creating folders, especially if this application runs as root user
 	if root != "." {
 		err := os.Chdir(root)
 		if err != nil {
@@ -24,11 +26,14 @@ func Init(root string, context map[string]interface{}) {
 	}
 
 	parseConfiguration(context)
-	InitLogs()
+	InitLogs(viper.GetString("log.level"))
 
-	tracing := viper.GetBool("tracing.enabled")
-	if tracing {
-		InitTracing()
+	if viper.GetBool("tracing.enabled") {
+		InitTracing(
+			KafkaTracingConfig{
+				BootstrapServers: strings.Split(viper.GetString("kafka.bootstrapservers"), ","),
+				TracingName:      viper.GetString("tracing.service.name"),
+			})
 	}
 
 	health := viper.GetBool("healthcheck.enabled")

--- a/pprof.go
+++ b/pprof.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 )
 
-// InitPprof starts an HTTP endpoint on serverPort
+// InitPprof starts an HTTP server on serverPort
+// the application must import the package http/pprof to enable pprof.
+// it's required to start a new HTTP server because http/pprof init() calls http.HandleFunc, so we cannot attach it to an existing router
+// see https://golang.org/src/net/http/pprof/pprof.go?s=6833:6871#L211
 func InitPprof(serverPort int) {
 	go func() {
 		err := http.ListenAndServe(fmt.Sprintf(":%d", serverPort), nil)

--- a/prometheus.go
+++ b/prometheus.go
@@ -1,36 +1,17 @@
 package gorillaz
 
 import (
-	"net/http"
-	"strconv"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const prometheusEndpoint = "prometheus.endpoint"
-
-// PromConfig is prometheus handler configuration
-type PromConfig struct {
-	Path string // URL path where to expose metrics
-	Port int    // TCP port to start Prometheus server
-}
-
-// InitPrometheus starts a HTTP server on port conf.Port and exposes metrics on path conf.Path
-func InitPrometheus(conf PromConfig) {
-	go startPrometheusEndpoint(conf)
-}
-
-func startPrometheusEndpoint(conf PromConfig) {
-	port := conf.Port
-	path := conf.Path
-	if !strings.HasPrefix("/", path) {
+// InitPrometheus registers Prometheus handler to path to expose metrics via HTTP
+func InitPrometheus(router *mux.Router, path string) {
+	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	Sugar.Infof("Starting Prometheus endpoint %s on port %d", path, port)
-	http.Handle(path, promhttp.Handler())
-	err := http.ListenAndServe(":"+strconv.Itoa(port), nil)
-	if err != nil {
-		Sugar.Warnf("Prometheus endpoint stopped%v", err)
-	}
+	Sugar.Infof("Setup Prometheus handler at %s", path)
+	router.Handle(path, promhttp.Handler()).Methods("GET")
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -2,16 +2,15 @@ package gorillaz
 
 import (
 	"net/http"
-	"path"
-	"runtime/debug"
 	"strconv"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const prometheusEndpoint = "prometheus.endpoint"
 
-// Prometheus handler configuration
+// PromConfig is prometheus handler configuration
 type PromConfig struct {
 	Path string // URL path where to expose metrics
 	Port int    // TCP port to start Prometheus server
@@ -23,21 +22,15 @@ func InitPrometheus(conf PromConfig) {
 }
 
 func startPrometheusEndpoint(conf PromConfig) {
-	//TODO: can it panic?
-	defer recovery()
 	port := conf.Port
-	endpoint := path.Join("/", conf.Path)
-	Sugar.Infof("Starting Prometheus endpoint %s on port %d", endpoint, port)
-	http.Handle(path.Join("/", endpoint), promhttp.Handler())
+	path := conf.Path
+	if !strings.HasPrefix("/", path) {
+		path = "/" + path
+	}
+	Sugar.Infof("Starting Prometheus endpoint %s on port %d", path, port)
+	http.Handle(path, promhttp.Handler())
 	err := http.ListenAndServe(":"+strconv.Itoa(port), nil)
 	if err != nil {
 		Sugar.Warnf("Prometheus endpoint stopped%v", err)
-	}
-}
-
-func recovery() {
-	if r := recover(); r != nil {
-		Sugar.Warnf("Error while starting Prometheus endpoint %v", r)
-		debug.PrintStack()
 	}
 }

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -1,0 +1,29 @@
+package gorillaz
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+//TestPrometheusInit tests the creation of a prometheus endpoint and the given path
+func TestPrometheusInit(t *testing.T) {
+	SetupLogger()
+	router := mux.NewRouter()
+	path := "/somemetric"
+	InitPrometheus(router, path)
+
+	port, shutdown := setupServerHTTP(router)
+	defer shutdown()
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", port, path))
+	if err != nil {
+		t.Errorf("cannot query metrics endpoint, %+v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected http status %d but got %d", http.StatusOK, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
General comments:
* Having a standard way of building a kafka based service is the way to go. It provides a way to define what are the standard libraries, how a service looks like, how to do logging, tracing, etc. It also allows onboarding and will reduce the cost of maintenance (fixing once for all apps).
* This lib doesn't contain a lot of tests nor comments.
* Some parts are very much work in progress (the prometheus and elasticsearch for instance)

Proposals:
* Reduce the amount of places where we parse flags. This will make the code more testable (no need to have actual argument parsing to test something simple)
* Simplify the configuration management if possible
** I don't understand why config.go is so complex, why we look in so many different places for configuration. Having 1 way of doing things should make our life simpler
* Add a README with a proper description, so newbies like me have a simpler life
* Extract the upload of templates to Elasticsearch (I have no idea why it's here to be honest)
* Finish & polish the Prometheus with very basic tests
* Finish & polish the healthcheck/ready with very basic tests
* Clarify what's the expected lifecycle of such an application
* Try to implement some very basic unit tests for untested components to be sure it's testable as it is or if we need to refactor a bit more the structure.

Questions:
* Do we need to start new HTTP servers for healthcheck / ready & prometheus? I have the feeling we're making things more complicated than it could be.
* The Opentracing part is kindda complex. There is probably a reason for this, but it's a lot of code! Isn't there a simpler way?
* Do we need rxgo? Do you have a bit of time to explain me why it's here in the first place?