### PR TITLE
easy stream consumers

### DIFF
--- a/cmd/testConsumerProducer/main.go
+++ b/cmd/testConsumerProducer/main.go
@@ -39,18 +39,15 @@ func main() {
 		config.UseGzip = true
 	}
 
-	endpoint, err := g.NewStreamEndpoint(strings.Split(endpoints, ","))
-
+	consumer, err := g.ConsumeStream(strings.Split(endpoints, ","), streamName, opt)
 	if err != nil {
 		panic(err)
 	}
 
-	consumer := endpoint.ConsumeStream(streamName, opt)
-
 	fmt.Println("client created")
 
 	for {
-		evt := <-consumer.EvtChan
+		evt := <-consumer.EvtChan()
 		sp, _ := opentracing.StartSpanFromContext(evt.Ctx, "computing latency")
 		latency := time.Now().UnixNano() - stream.StreamTimestamp(evt)
 		if latency > worstLatency {

--- a/cmd/testFinalConsumer/main.go
+++ b/cmd/testFinalConsumer/main.go
@@ -21,7 +21,7 @@ func main() {
 	flag.StringVar(&endpoints, "endpoints", "", "endpoint to connect to")
 	flag.Parse()
 
-	g := gaz.New()
+	g := gaz.New(gaz.WithStreamEndpointOptions(gaz.BackoffMaxDelay(3 * time.Second)))
 	g.Run()
 
 	var wg sync.WaitGroup

--- a/cmd/testFinalConsumer/main.go
+++ b/cmd/testFinalConsumer/main.go
@@ -30,13 +30,10 @@ func main() {
 	var worstLatency int64
 	var totalLatency int64
 
-	endpoint, err := g.NewStreamEndpoint(strings.Split(endpoints, ","))
-
+	consumer, err := g.ConsumeStream(strings.Split(endpoints, ","), streamName)
 	if err != nil {
 		panic(err)
 	}
-
-	consumer := endpoint.ConsumeStream(streamName)
 
 	fmt.Println("client created")
 
@@ -50,7 +47,7 @@ func main() {
 		if i%1000 == 0 {
 			fmt.Println(fmt.Sprintf("consumed %d messages", i))
 		}
-		evt := <-consumer.EvtChan
+		evt := <-consumer.EvtChan()
 		sp, _ := opentracing.StartSpanFromContext(evt.Ctx, "computing latency")
 		latency := time.Now().UnixNano() - stream.StreamTimestamp(evt)
 		if latency > worstLatency {

--- a/config.go
+++ b/config.go
@@ -1,83 +1,15 @@
 package gorillaz
 
 import (
-	"bufio"
 	"flag"
-	"io"
-	"log"
-	"os"
-	"path"
-	"strings"
-
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
+	"log"
 )
 
-const multilineSeparator = "\\"
-
-func parseProperties(reader io.Reader) map[string]string {
-	scanner := bufio.NewScanner(reader)
-	m := make(map[string]string)
-	var multiline string
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		// Comments
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		if strings.HasSuffix(line, multilineSeparator) {
-			multiline += strings.TrimSuffix(line, multilineSeparator)
-			continue
-		} else {
-			if len(multiline) > 0 {
-				line = multiline + line
-				multiline = ""
-			}
-		}
-
-		split := strings.Split(line, "=")
-		if len(split) < 2 {
-			if len(line) > 0 {
-				log.Printf("WARN: cannot parse config line %s\n", line)
-			}
-			continue
-		}
-		m[split[0]] = split[1]
-	}
-	return m
-}
-
-func parsePropertyFileAndSetFlags(filename string) error {
-	f, err := os.Open(filename)
-	if err != nil {
-		log.Fatalf("Unable to open properties file %v", filename)
-		return err
-	}
-	defer func() {
-		err := f.Close()
-		if err != nil {
-			log.Printf("unable to close file %s, %+v", filename, err)
-		}
-	}()
-
-	kv := parseProperties(f)
-
-	for k, v := range kv {
-		if f := flag.Lookup(k); f != nil {
-			setFlagValue(k, v)
-		} else {
-			flag.String(k, v, "")
-		}
-	}
-	return nil
-}
-
-func parseConfiguration(configPath string) {
-	// If parsing already done
-	conf := GetConfigPath(configPath)
-
+//Define flags supported by gorillaz
+func init() {
 	flag.String("env", "dev", "Environment")
+	flag.String("conf", "configs", "config folder. default: configs")
 	flag.String("log.level", "", "Log level")
 	flag.String("service.name", "", "Service name")
 	flag.String("service.address", "", "Service address")
@@ -90,16 +22,23 @@ func parseConfiguration(configPath string) {
 	flag.Bool("prometheus.enabled", true, "Prometheus enabled")
 	flag.Int("http.port", 0, "http port")
 	flag.Int("grpc.port", 0, "grpc port")
+}
 
-	err := parsePropertyFileAndSetFlags(path.Join(conf, "application.properties"))
+func parseConfiguration(g *Gaz, configPath string) {
+	conf := GetConfigPath(configPath)
+
+	const configFilePrefix = "application"
+	g.Viper.SetConfigName(configFilePrefix) //the suffix ".properties" will be added by viper
+	g.Viper.AddConfigPath(conf)
+	err := g.Viper.ReadInConfig()
 	if err != nil {
-		log.Fatalf("unable to read and extract key/value in %s: %v", conf+"/application.properties", err)
+		Sugar.Warnf("unable to read config in path %s with file prefix %s %v", conf, configFilePrefix, err)
 	}
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	err = viper.BindPFlags(pflag.CommandLine)
+	err = g.Viper.BindPFlags(pflag.CommandLine)
 	if err != nil {
 		log.Fatalf("unable to bind flags: %v", err)
 	}
@@ -112,28 +51,5 @@ func GetConfigPath(configPath string) string {
 	if f := flag.Lookup("conf"); f != nil {
 		return f.Value.String()
 	}
-	var conf string
-	flag.StringVar(&conf, "conf", "configs", "config folder. default: configs")
-	return conf
-}
-
-func getFlagValue(name string) string {
-	result := ""
-	flag.VisitAll(func(f *flag.Flag) {
-		if f.Name == name {
-			result = f.Value.String()
-		}
-	})
-	return result
-}
-
-func setFlagValue(name string, value string) {
-	flag.VisitAll(func(f *flag.Flag) {
-		if f.Name == name {
-			err := f.Value.Set(value)
-			if err != nil {
-				log.Printf("Could not set value for flag %s : %s\n", name, err)
-			}
-		}
-	})
+	return ""
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/gorilla/mux v1.7.0
 	github.com/json-iterator/go v1.1.7 // indirect
+	github.com/magiconair/properties v1.8.0
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/gorilla/mux v1.7.0
 	github.com/json-iterator/go v1.1.7 // indirect
-	github.com/magiconair/properties v1.8.0
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/prometheus/common v0.4.0
 	github.com/sirupsen/logrus v1.4.1 // indirect

--- a/gorillaz.go
+++ b/gorillaz.go
@@ -48,8 +48,8 @@ type Gaz struct {
 type streamConsumerRegistry struct {
 	sync.Mutex
 	g                 *Gaz
-	endpointsByName   map[string]*StreamEndpoint
-	endpointConsumers map[*StreamEndpoint]map[*registeredConsumer]struct{}
+	endpointsByName   map[string]*streamEndpoint
+	endpointConsumers map[*streamEndpoint]map[*registeredConsumer]struct{}
 }
 
 type GazOption interface {
@@ -101,8 +101,8 @@ func New(options ...GazOption) *Gaz {
 	gaz.httpSrv = &http.Server{Handler: gaz.Router}
 	gaz.streamConsumers = &streamConsumerRegistry{
 		g:                 &gaz,
-		endpointsByName:   make(map[string]*StreamEndpoint),
-		endpointConsumers: make(map[*StreamEndpoint]map[*registeredConsumer]struct{}),
+		endpointsByName:   make(map[string]*streamEndpoint),
+		endpointConsumers: make(map[*streamEndpoint]map[*registeredConsumer]struct{}),
 	}
 
 	// first apply only init options

--- a/gorillaz.go
+++ b/gorillaz.go
@@ -32,14 +32,15 @@ type Gaz struct {
 	ViperRemoteConfig bool
 	Env               string
 	// use int32 because sync.atomic package doesn't support boolean out of the box
-	isReady           *int32
-	isLive            *int32
-	streamRegistry    *streamRegistry
-	grpcListener      net.Listener
-	grpcServerOptions []grpc.ServerOption
-	configPath        string
-	serviceAddress    string // optional address of the service that will be used for service discovery
-	streamConsumers   *streamConsumerRegistry
+	isReady               *int32
+	isLive                *int32
+	streamRegistry        *streamRegistry
+	grpcListener          net.Listener
+	grpcServerOptions     []grpc.ServerOption
+	configPath            string
+	serviceAddress        string // optional address of the service that will be used for service discovery
+	streamConsumers       *streamConsumerRegistry
+	streamEndpointOptions []StreamEndpointConfigOpt
 }
 
 type streamConsumerRegistry struct {
@@ -56,10 +57,9 @@ func (g *Gaz) createConsumer(endpoints []string, streamName string, opts ...Cons
 	target := strings.Join(endpoints, ",")
 	e, ok := r.endpointsByName[target]
 	if !ok {
-		//TODO pass options with gorillaz options
 		var err error
 		Log.Debug("Creating stream endpoint", zap.String("target", target))
-		e, err = r.g.NewStreamEndpoint(endpoints)
+		e, err = r.g.NewStreamEndpoint(endpoints, g.streamEndpointOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -6,7 +6,7 @@ import (
 )
 
 // InitHealthcheck registers /live and /ready (GET) for liveness and readiness probes in k8s
-func (g Gaz) InitHealthcheck() {
+func (g *Gaz) InitHealthcheck() {
 	ready := func(w http.ResponseWriter, _ *http.Request) {
 		if atomic.LoadInt32(g.isReady) == 1 {
 			w.WriteHeader(http.StatusOK)
@@ -28,7 +28,7 @@ func (g Gaz) InitHealthcheck() {
 }
 
 // SetReady returns the actual internal state to precise if the given microservice is ready
-func (g Gaz) SetReady(status bool) {
+func (g *Gaz) SetReady(status bool) {
 	var statusInt int32
 	if status {
 		statusInt = 1
@@ -37,7 +37,7 @@ func (g Gaz) SetReady(status bool) {
 }
 
 // SetLive returns the actual internal state to precise if the given microservice is live
-func (g Gaz) SetLive(status bool) {
+func (g *Gaz) SetLive(status bool) {
 	var statusInt int32
 	if status {
 		statusInt = 1

--- a/log.go
+++ b/log.go
@@ -35,7 +35,7 @@ func init() {
 
 // InitLogs initializes the Sugar (*zap.SugaredLogger) and Log (*zap.Logger) elements
 // returns an error if logLevel can't be mapped to a zapcore.LogLevel, otherwise returns nil
-func (Gaz) InitLogs(logLevel string) error {
+func (*Gaz) InitLogs(logLevel string) error {
 	level, err := zapLogLevel(logLevel)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func (Gaz) InitLogs(logLevel string) error {
 }
 
 // LogLevel returns the current log level
-func (Gaz) LogLevel() zapcore.Level {
+func (*Gaz) LogLevel() zapcore.Level {
 	return atomLevel.Level()
 }
 

--- a/pprof.go
+++ b/pprof.go
@@ -10,7 +10,7 @@ import (
 // the application must import the package http/pprof to enable pprof.
 // it's required to start a new HTTP server because http/pprof init() calls http.HandleFunc, so we cannot attach it to an existing router
 // see https://golang.org/src/net/http/pprof/pprof.go?s=6833:6871#L211
-func (g Gaz) InitPprof(serverPort int) {
+func (g *Gaz) InitPprof(serverPort int) {
 	go func() {
 		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", serverPort))
 		if err != nil {

--- a/prometheus.go
+++ b/prometheus.go
@@ -10,7 +10,7 @@ import (
 )
 
 // InitPrometheus registers Prometheus handler to path to expose metrics via HTTP
-func (g Gaz) InitPrometheus(path string) {
+func (g *Gaz) InitPrometheus(path string) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-
-	"github.com/gorilla/mux"
 )
 
 //TestPrometheusInit tests the creation of a prometheus endpoint and the given path
 func TestPrometheusInit(t *testing.T) {
 	SetupLogger()
 	path := "/somemetric"
-	gaz := &Gaz{Router: mux.NewRouter()}
+	gaz := New(WithServiceName("promtest"))
+	defer gaz.Shutdown()
 	gaz.InitPrometheus(path)
 
 	port, shutdown := setupServerHTTP(gaz.Router)

--- a/sd.go
+++ b/sd.go
@@ -123,7 +123,7 @@ func (r *gorillazDefaultResolver) start() {
 func (*gorillazDefaultResolver) ResolveNow(o resolver.ResolveNowOption) {}
 func (*gorillazDefaultResolver) Close()                                 {}
 
-func (g Gaz) Register(d *ServiceDefinition) (RegistrationHandle, error) {
+func (g *Gaz) Register(d *ServiceDefinition) (RegistrationHandle, error) {
 	if g.ServiceDiscovery == nil {
 		return nil, errors.New("no service registry configured")
 	}
@@ -131,10 +131,10 @@ func (g Gaz) Register(d *ServiceDefinition) (RegistrationHandle, error) {
 	return g.ServiceDiscovery.Register(d)
 }
 
-func (g Gaz) Resolve(serviceName string) ([]ServiceDefinition, error) {
+func (g *Gaz) Resolve(serviceName string) ([]ServiceDefinition, error) {
 	return g.ServiceDiscovery.Resolve(serviceName)
 }
 
-func (g Gaz) ResolveWithTag(serviceName, tag string) ([]ServiceDefinition, error) {
+func (g *Gaz) ResolveWithTag(serviceName, tag string) ([]ServiceDefinition, error) {
 	return g.ServiceDiscovery.ResolveWithTag(serviceName, tag)
 }

--- a/stream_consumer.go
+++ b/stream_consumer.go
@@ -113,26 +113,26 @@ type EndpointType uint8
 // Call this method to create a stream consumer with the full stream name (pattern: "serviceName.streamName")
 // The service name is resolved via service discovery
 // Under the hood we make sure that only 1 subscription is done for a service, even if multiple streams are created on the same service
-func (g *Gaz) DiscoverAndConsumeStream(fullStreamName string) (StreamConsumer, error) {
+func (g *Gaz) DiscoverAndConsumeStream(fullStreamName string, opts ...ConsumerConfigOpt) (StreamConsumer, error) {
 	srv, stream := ParseStreamName(fullStreamName)
-	return g.DiscoverAndConsumeServiceStream(srv, stream)
+	return g.DiscoverAndConsumeServiceStream(srv, stream, opts...)
 }
 
 // Call this method to create a stream consumer
 // The service name is resolved via service discovery
 // Under the hood we make sure that only 1 subscription is done for a service, even if multiple streams are created on the same service
-func (g *Gaz) DiscoverAndConsumeServiceStream(service, stream string) (StreamConsumer, error) {
-	return g.createConsumer([]string{SdPrefix + service}, stream)
+func (g *Gaz) DiscoverAndConsumeServiceStream(service, stream string, opts ...ConsumerConfigOpt) (StreamConsumer, error) {
+	return g.createConsumer([]string{SdPrefix + service}, stream, opts...)
 }
 
 // Call this method to create a stream consumer with the service endpoints and the stream name
 // Under the hood we make sure that only 1 subscription is done for a service, even if multiple streams are created on the same service
-func (g *Gaz) ConsumeStream(endpoints []string, stream string) (StreamConsumer, error) {
-	return g.createConsumer(endpoints, stream)
+func (g *Gaz) ConsumeStream(endpoints []string, stream string, opts ...ConsumerConfigOpt) (StreamConsumer, error) {
+	return g.createConsumer(endpoints, stream, opts...)
 }
 
 // Returns the stream endpoint for the given service name that will be discovered thanks to the service discovery mechanism
-func (g *Gaz) NewServiceStreamEndpoint(serviceName string) (*StreamEndpoint, error) {
+func (g *Gaz) NewServiceStreamEndpoint(serviceName string, opts ...StreamEndpointConfigOpt) (*StreamEndpoint, error) {
 	return g.NewStreamEndpoint([]string{SdPrefix + serviceName})
 }
 

--- a/stream_consumer.go
+++ b/stream_consumer.go
@@ -56,7 +56,7 @@ type consumer struct {
 	streamName string
 	evtChan    chan *stream.Event
 	config     *ConsumerConfig
-	stopped    int32
+	stopped    *int32
 }
 
 func (c *consumer) streamEndpoint() *StreamEndpoint {
@@ -72,11 +72,11 @@ func (c *consumer) EvtChan() chan *stream.Event {
 }
 
 func (c *consumer) Stop() bool {
-	return atomic.SwapInt32(&c.stopped, 1) == 1
+	return atomic.SwapInt32(c.stopped, 1) == 1
 }
 
 func (c *consumer) isStopped() bool {
-	return atomic.LoadInt32(&c.stopped) == 1
+	return atomic.LoadInt32(c.stopped) == 1
 }
 
 type StreamEndpoint struct {
@@ -185,6 +185,7 @@ func (se *StreamEndpoint) ConsumeStream(streamName string, opts ...ConsumerConfi
 		streamName: streamName,
 		evtChan:    ch,
 		config:     config,
+		stopped:    new(int32),
 	}
 
 	var monitoringHolder = consumerMonitoring(streamName, se.endpoints)

--- a/stream_consumer.go
+++ b/stream_consumer.go
@@ -110,6 +110,14 @@ type StreamEndpointConfigOpt func(config *StreamEndpointConfig)
 
 type EndpointType uint8
 
+// Add options for the stream endpoint creation, this can be used when stream endpoints are created under the hood by the methods below.
+func WithStreamEndpointOptions(opts ...StreamEndpointConfigOpt) Option {
+	return Option{Opt: func(gaz *Gaz) error {
+		gaz.streamEndpointOptions = opts
+		return nil
+	}}
+}
+
 // Call this method to create a stream consumer with the full stream name (pattern: "serviceName.streamName")
 // The service name is resolved via service discovery
 // Under the hood we make sure that only 1 subscription is done for a service, even if multiple streams are created on the same service

--- a/stream_provider.go
+++ b/stream_provider.go
@@ -236,17 +236,20 @@ func (r *streamRegistry) find(streamName string) (*StreamProvider, bool) {
 	return p, ok
 }
 
+func GetFullStreamName(serviceName, streamName string) string {
+	return fmt.Sprintf("%s.%s", serviceName, streamName)
+}
+
 func (r *streamRegistry) register(streamName, dataType string, p *StreamProvider) {
 	r.Lock()
 	if _, found := r.providers[streamName]; found {
 		panic("cannot register 2 providers with the same streamName: " + streamName)
 	}
 	r.providers[streamName] = p
-
 	port := p.gaz.grpcListener.Addr().(*net.TCPAddr).Port
 
 	if p.gaz.ServiceDiscovery != nil {
-		sid, err := p.gaz.Register(&ServiceDefinition{ServiceName: p.gaz.ServiceName + "/" + streamName,
+		sid, err := p.gaz.Register(&ServiceDefinition{ServiceName: GetFullStreamName(p.gaz.ServiceName, streamName),
 			Addr: p.gaz.serviceAddress,
 			Port: port,
 			Tags: []string{StreamTag},

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,7 +2,7 @@ package gorillaz
 
 import (
 	"bytes"
-	"github.com/magiconair/properties/assert"
+	"fmt"
 	"github.com/skysoft-atm/gorillaz/stream"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -46,11 +46,17 @@ func TestFullStreamName(t *testing.T) {
 	const srv = "toto.tutu"
 	const str = "stream"
 	serv, stream := ParseStreamName(full)
-	assert.Equal(t, serv, srv, "as service name")
-	assert.Equal(t, stream, str, "as stream")
+	assertEquals(t, serv, srv, "as service name")
+	assertEquals(t, stream, str, "as stream")
 
 	name := GetFullStreamName(srv, str)
-	assert.Equal(t, name, full, "as full stream name")
+	assertEquals(t, name, full, "as full stream name")
+}
+
+func assertEquals(t *testing.T, got, expected, comment string) {
+	if got != expected {
+		t.Error(fmt.Sprintf("%s Got: %s Expected: %s", comment, got, expected))
+	}
 }
 
 func TestStreamLazy(t *testing.T) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -4,42 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/skysoft-atm/gorillaz/stream"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/resolver"
-	"net"
 	"testing"
 	"time"
 )
-
-func newGaz() (gaz *Gaz, addr string, shutdown func()) {
-	return newGazOnAddr(":0")
-}
-
-func newGazOnAddr(conAddr string) (gaz *Gaz, addr string, shutdown func()) {
-	l, err := net.Listen("tcp", conAddr)
-	if err != nil {
-		panic(err)
-	}
-	g := &Gaz{
-		GrpcServer:   grpc.NewServer(grpc.CustomCodec(&binaryCodec{})),
-		grpcListener: l,
-		ServiceName:  "test",
-		Env:          "test",
-		streamRegistry: &streamRegistry{
-			providers:  make(map[string]*StreamProvider),
-			serviceIds: make(map[string]RegistrationHandle),
-		},
-	}
-
-	stream.RegisterStreamServer(g.GrpcServer, g.streamRegistry)
-	go g.GrpcServer.Serve(l)
-	Log.Info("Started gRPC server", zap.String("Address", l.Addr().String()))
-	resolver.Register(&gorillazResolverBuilder{gaz: g})
-	return g, l.Addr().String(), func() {
-		g.GrpcServer.Stop()
-	}
-}
 
 func TestFullStreamName(t *testing.T) {
 	const full = "toto.tutu.stream"
@@ -60,9 +27,9 @@ func assertEquals(t *testing.T, got, expected, comment string) {
 }
 
 func TestStreamLazy(t *testing.T) {
-	g, addr, shutdown := newGaz()
-	g.InitLogs("debug")
-	defer shutdown()
+	g := New(WithServiceName("test"), WithMockedServiceDiscovery())
+	defer g.Shutdown()
+	<-g.Run()
 
 	provider, err := g.NewStreamProvider("stream", "dummy.type", func(conf *ProviderConfig) {
 		conf.LazyBroadcast = true
@@ -76,21 +43,19 @@ func TestStreamLazy(t *testing.T) {
 	provider.Submit(&stream.Event{Value: []byte("value1")})
 	provider.Submit(&stream.Event{Value: []byte("value2")})
 
-	endpoint, err := g.NewStreamEndpoint([]string{addr})
+	consumer, err := g.DiscoverAndConsumeServiceStream("does not mater", "stream")
 	if err != nil {
-		t.Errorf("cannot start consumer, %+v", err)
-		return
+		t.Fatal(err)
 	}
-
-	consumer := endpoint.ConsumeStream("stream")
 
 	assertReceived(t, "stream", consumer.EvtChan(), &stream.Event{Value: []byte("value1")})
 	assertReceived(t, "stream", consumer.EvtChan(), &stream.Event{Value: []byte("value2")})
 }
 
 func TestStreamEvents(t *testing.T) {
-	g, addr, shutdown := newGaz()
-	defer shutdown()
+	g := New(WithServiceName("test"), WithMockedServiceDiscovery())
+	defer g.Shutdown()
+	<-g.Run()
 
 	provider1Stream := "testy"
 	provider2Stream := "testoo"
@@ -107,8 +72,8 @@ func TestStreamEvents(t *testing.T) {
 		return
 	}
 
-	consumer1 := createConsumer(t, g, provider1Stream, addr)
-	consumer2 := createConsumer(t, g, provider2Stream, addr)
+	consumer1 := createConsumer(t, g, provider1Stream)
+	consumer2 := createConsumer(t, g, provider2Stream)
 
 	evt1 := &stream.Event{
 		Key:   []byte("testyKey"),
@@ -132,8 +97,9 @@ func TestStreamEvents(t *testing.T) {
 }
 
 func TestMultipleConsumers(t *testing.T) {
-	g, addr, shutdown := newGaz()
-	defer shutdown()
+	g := New(WithServiceName("test"), WithMockedServiceDiscovery())
+	defer g.Shutdown()
+	<-g.Run()
 
 	streamName := "testaa"
 
@@ -145,9 +111,9 @@ func TestMultipleConsumers(t *testing.T) {
 		return
 	}
 
-	consumer1 := createConsumer(t, g, streamName, addr)
-	consumer2 := createConsumer(t, g, streamName, addr)
-	consumer3 := createConsumer(t, g, streamName, addr)
+	consumer1 := createConsumer(t, g, streamName)
+	consumer2 := createConsumer(t, g, streamName)
+	consumer3 := createConsumer(t, g, streamName)
 
 	// give time to the consumers to be properly subscribed
 	time.Sleep(time.Second * 3)
@@ -166,8 +132,9 @@ func TestMultipleConsumers(t *testing.T) {
 }
 
 func TestProducerReconnect(t *testing.T) {
-	g, addr, shutdown := newGaz()
-	defer shutdown()
+	mock, sdOption := NewMockedServiceDiscovery()
+	g := New(WithServiceName("test"), sdOption)
+	<-g.Run()
 
 	streamName := "testaa"
 
@@ -182,17 +149,23 @@ func TestProducerReconnect(t *testing.T) {
 	// as this is a lazy provider, it should wait for a first consumer to send events
 	provider.Submit(&stream.Event{Value: []byte("value1")})
 
-	consumer := createConsumer(t, g, streamName, addr)
+	consumer, err := g.DiscoverAndConsumeServiceStream("does not matter", streamName)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assertReceived(t, "stream", consumer.EvtChan(), &stream.Event{Value: []byte("value1")})
 
 	// disconnect the provider
-	shutdown()
+	g.Shutdown()
 
 	// wait a bit to be sure the consumer has seen it
 	time.Sleep(time.Second)
 
-	g, _, shutdown = newGazOnAddr(addr)
+	g = New(WithServiceName("test"))
+	<-g.Run()
+	mock.UpdateGaz(g)
+	defer g.Shutdown()
 	provider2, err := g.NewStreamProvider(streamName, "dummy.type")
 	if err != nil {
 		t.Errorf("cannot start provider, %+v", err)
@@ -220,7 +193,7 @@ func assertReceived(t *testing.T, streamName string, ch <-chan *stream.Event, ex
 	}
 }
 
-func createConsumer(t *testing.T, g *Gaz, streamName string, endpoint string) StreamConsumer {
+func createConsumer(t *testing.T, g *Gaz, streamName string) StreamConsumer {
 	connected := make(chan bool, 1)
 
 	opt := func(config *ConsumerConfig) {
@@ -234,13 +207,10 @@ func createConsumer(t *testing.T, g *Gaz, streamName string, endpoint string) St
 		}
 	}
 
-	streamEndpoint, err := g.NewStreamEndpoint([]string{endpoint})
+	consumer, err := g.DiscoverAndConsumeServiceStream("does not matter", streamName, opt)
 	if err != nil {
-		t.Errorf("cannot create consumer for stream %s,, %+v", streamName, err)
-		t.FailNow()
+		t.Fatal(err)
 	}
-
-	consumer := streamEndpoint.ConsumeStream(streamName, opt)
 
 	select {
 	case <-connected:

--- a/trace.go
+++ b/trace.go
@@ -5,7 +5,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	zlog "github.com/opentracing/opentracing-go/log"
 	"github.com/skysoft-atm/zipkin-go-light-opentracing"
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"log"
 )
@@ -30,13 +29,13 @@ func (g *Gaz) InitTracingFromConfig() {
 		collectorUrl, err = g.resolveZipkinUrlFromServiceDiscovery()
 		if err != nil {
 			Log.Info("Error while resolving zipkin from service discovery", zap.Error(err))
-			collectorUrl = viper.GetString("tracing.collector.url")
+			collectorUrl = g.Viper.GetString("tracing.collector.url")
 		} else if err != nil {
 			Log.Info("No zipkin instance found in service discovery")
-			collectorUrl = viper.GetString("tracing.collector.url")
+			collectorUrl = g.Viper.GetString("tracing.collector.url")
 		}
 	} else {
-		collectorUrl = viper.GetString("tracing.collector.url")
+		collectorUrl = g.Viper.GetString("tracing.collector.url")
 	}
 
 	g.InitTracing(

--- a/trace.go
+++ b/trace.go
@@ -23,7 +23,7 @@ type TracingConfig struct {
 // InitTracingFromConfig initializes either an HTTP connection to a Zipkin Collector
 // You should have provided the following configurations, either in the config file or with flags:
 // zipkin.collector.url
-func (g Gaz) InitTracingFromConfig() {
+func (g *Gaz) InitTracingFromConfig() {
 	var collectorUrl string
 	if g.ServiceDiscovery != nil {
 		var err error
@@ -46,7 +46,7 @@ func (g Gaz) InitTracingFromConfig() {
 		})
 }
 
-func (g Gaz) resolveZipkinUrlFromServiceDiscovery() (string, error) {
+func (g *Gaz) resolveZipkinUrlFromServiceDiscovery() (string, error) {
 	tracingEndpoints, err := g.ResolveWithTag("zipkin", g.Env)
 	if err != nil {
 		return "", err
@@ -58,7 +58,7 @@ func (g Gaz) resolveZipkinUrlFromServiceDiscovery() (string, error) {
 }
 
 // InitTracing initializes connection to feed Zipkin
-func (g Gaz) InitTracing(conf TracingConfig) {
+func (g *Gaz) InitTracing(conf TracingConfig) {
 
 	if conf.collectorUrl == "" {
 		panic("zipkin TracingConfig is invalid, collectorUrl is not set")


### PR DESCRIPTION
The goal of this change is to simplify the creation of stream consumers.
Before, to create a consumer, we had to first create a stream endpoint, and then create a consumer on this endpoint.
This means that we had to manually do some bookkeeping of the endpoints in the services to make sure that
- only 1 stream endpoint is created per remote service we want to connect to
- the stream endpoint is properly closed once all streams linked to this endpoint are no longer needed

This bookkeeping is now done in gorillaz, which means that we can create stream consumers directly (see the new methods in stream_consumer.go)

The old way to create endpoints and streams is still available, so you are free to upgrade if and when you want.
I just add to abstract the Consumer struct into a StreamConsumer, so this will not be backward compatible (we just need to replace fields by method calls).

I had to roll back to using a pointer for the function with receiver on Gaz since we are now mutating the Gaz object after its initialization.