### PR TITLE
Make testing great again

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,11 +27,12 @@ func init() {
 func parseConfiguration(g *Gaz, configPath string) {
 	conf := GetConfigPath(configPath)
 
-	g.Viper.SetConfigName("application") //the suffix ".properties" will be added by viper
+	const configFilePrefix = "application"
+	g.Viper.SetConfigName(configFilePrefix) //the suffix ".properties" will be added by viper
 	g.Viper.AddConfigPath(conf)
 	err := g.Viper.ReadInConfig()
 	if err != nil {
-		panic(err)
+		Sugar.Warnf("unable to read config in path %s with file prefix %s %v", conf, configFilePrefix, err)
 	}
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/config.go
+++ b/config.go
@@ -1,80 +1,15 @@
 package gorillaz
 
 import (
-	"bufio"
 	"flag"
-	"io"
-	"log"
-	"os"
-	"path"
-	"strings"
-
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
+	"log"
 )
 
-const multilineSeparator = "\\"
-
-func parseProperties(reader io.Reader) map[string]string {
-	scanner := bufio.NewScanner(reader)
-	m := make(map[string]string)
-	var multiline string
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		// Comments
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		if strings.HasSuffix(line, multilineSeparator) {
-			multiline += strings.TrimSuffix(line, multilineSeparator)
-			continue
-		} else {
-			if len(multiline) > 0 {
-				line = multiline + line
-				multiline = ""
-			}
-		}
-
-		split := strings.Split(line, "=")
-		if len(split) < 2 {
-			if len(line) > 0 {
-				log.Printf("WARN: cannot parse config line %s\n", line)
-			}
-			continue
-		}
-		m[split[0]] = split[1]
-	}
-	return m
-}
-
-func parsePropertyFileAndSetFlags(filename string) error {
-	f, err := os.Open(filename)
-	if err != nil {
-		log.Fatalf("Unable to open properties file %v", filename)
-		return err
-	}
-	defer func() {
-		err := f.Close()
-		if err != nil {
-			log.Printf("unable to close file %s, %+v", filename, err)
-		}
-	}()
-
-	kv := parseProperties(f)
-
-	for k, v := range kv {
-		if f := flag.Lookup(k); f != nil {
-			setFlagValue(k, v)
-		} else {
-			flag.String(k, v, "")
-		}
-	}
-	return nil
-}
-
+//Define flags supported by gorillaz
 func init() {
 	flag.String("env", "dev", "Environment")
+	flag.String("conf", "configs", "config folder. default: configs")
 	flag.String("log.level", "", "Log level")
 	flag.String("service.name", "", "Service name")
 	flag.String("service.address", "", "Service address")
@@ -89,19 +24,20 @@ func init() {
 	flag.Int("grpc.port", 0, "grpc port")
 }
 
-func parseConfiguration(configPath string) {
-	// If parsing already done
+func parseConfiguration(g *Gaz, configPath string) {
 	conf := GetConfigPath(configPath)
 
-	err := parsePropertyFileAndSetFlags(path.Join(conf, "application.properties"))
+	g.Viper.SetConfigName("application") //the suffix ".properties" will be added by viper
+	g.Viper.AddConfigPath(conf)
+	err := g.Viper.ReadInConfig()
 	if err != nil {
-		log.Fatalf("unable to read and extract key/value in %s: %v", conf+"/application.properties", err)
+		panic(err)
 	}
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	err = viper.BindPFlags(pflag.CommandLine)
+	err = g.Viper.BindPFlags(pflag.CommandLine)
 	if err != nil {
 		log.Fatalf("unable to bind flags: %v", err)
 	}
@@ -114,28 +50,5 @@ func GetConfigPath(configPath string) string {
 	if f := flag.Lookup("conf"); f != nil {
 		return f.Value.String()
 	}
-	var conf string
-	flag.StringVar(&conf, "conf", "configs", "config folder. default: configs")
-	return conf
-}
-
-func getFlagValue(name string) string {
-	result := ""
-	flag.VisitAll(func(f *flag.Flag) {
-		if f.Name == name {
-			result = f.Value.String()
-		}
-	})
-	return result
-}
-
-func setFlagValue(name string, value string) {
-	flag.VisitAll(func(f *flag.Flag) {
-		if f.Name == name {
-			err := f.Value.Set(value)
-			if err != nil {
-				log.Printf("Could not set value for flag %s : %s\n", name, err)
-			}
-		}
-	})
+	return ""
 }

--- a/config.go
+++ b/config.go
@@ -73,10 +73,7 @@ func parsePropertyFileAndSetFlags(filename string) error {
 	return nil
 }
 
-func parseConfiguration(configPath string) {
-	// If parsing already done
-	conf := GetConfigPath(configPath)
-
+func init() {
 	flag.String("env", "dev", "Environment")
 	flag.String("log.level", "", "Log level")
 	flag.String("service.name", "", "Service name")
@@ -90,6 +87,11 @@ func parseConfiguration(configPath string) {
 	flag.Bool("prometheus.enabled", true, "Prometheus enabled")
 	flag.Int("http.port", 0, "http port")
 	flag.Int("grpc.port", 0, "grpc port")
+}
+
+func parseConfiguration(configPath string) {
+	// If parsing already done
+	conf := GetConfigPath(configPath)
 
 	err := parsePropertyFileAndSetFlags(path.Join(conf, "application.properties"))
 	if err != nil {

--- a/gorillaz.go
+++ b/gorillaz.go
@@ -31,6 +31,7 @@ type Gaz struct {
 	ServiceName       string
 	ViperRemoteConfig bool
 	Env               string
+	Viper             *viper.Viper
 	// use int32 because sync.atomic package doesn't support boolean out of the box
 	isReady               *int32
 	isLive                *int32
@@ -144,7 +145,7 @@ func New(options ...GazOption) *Gaz {
 	}
 	initialized = true
 	GracefulStop()
-	gaz := Gaz{Router: mux.NewRouter(), isReady: new(int32), isLive: new(int32)}
+	gaz := Gaz{Router: mux.NewRouter(), isReady: new(int32), isLive: new(int32), Viper: viper.New()}
 
 	gaz.streamConsumers = &streamConsumerRegistry{
 		g:                 &gaz,

--- a/prometheus.go
+++ b/prometheus.go
@@ -2,7 +2,7 @@ package gorillaz
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/zap"
 	"strings"
 	"time"
 
@@ -14,20 +14,37 @@ func (g *Gaz) InitPrometheus(path string) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
+	g.prometheusRegistry = prometheus.NewRegistry()
 	Sugar.Infof("Setup Prometheus handler at %s", path)
 	g.Router.Handle(path, promhttp.Handler()).Methods("GET")
 
 	// export uptime as a prometheus counter
-	upCounter := promauto.NewCounter(prometheus.CounterOpts{
+	upCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "uptime_sec",
 		Help: "uptime in seconds",
 	})
+	if g.RegisterCollector(upCounter) {
+		go func() {
+			t := time.Tick(time.Second)
+			for {
+				<-t
+				upCounter.Inc()
+			}
+		}()
+	}
+}
 
-	go func() {
-		t := time.Tick(time.Second)
-		for {
-			<-t
-			upCounter.Inc()
+// return true if collector was successfully registered
+func (g *Gaz) RegisterCollector(c prometheus.Collector) bool {
+	if g.prometheusRegistry != nil {
+		err := g.prometheusRegistry.Register(c)
+		if err != nil {
+			Log.Warn("Could not register prometheus collector", zap.Error(err))
+			return false
 		}
-	}()
+		return true
+	} else {
+		Log.Info("No prometheus registry found")
+		return false
+	}
 }

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-
-	"github.com/gorilla/mux"
 )
 
 //TestPrometheusInit tests the creation of a prometheus endpoint and the given path
 func TestPrometheusInit(t *testing.T) {
 	SetupLogger()
 	path := "/somemetric"
-	gaz := &Gaz{Router: mux.NewRouter()}
+	gaz := New(WithServiceName("promtest"))
+	defer gaz.Shutdown()
 	gaz.InitPrometheus(path)
 
 	port, shutdown := setupServerHTTP(gaz.Router)

--- a/stream_test.go
+++ b/stream_test.go
@@ -59,6 +59,24 @@ func assertEquals(t *testing.T, got, expected, comment string) {
 	}
 }
 
+func TestTwoGazStreamName(t *testing.T) {
+	gaz1 := New(WithConfigPath("./testConfig"))
+
+	gaz1.Run()
+	fmt.Println("gaz1 started")
+	time.Sleep(1 * time.Second)
+	gaz1.Shutdown()
+	fmt.Println("gaz1 stopped")
+	time.Sleep(1 * time.Second)
+	gaz2 := New(WithConfigPath("./testConfig"))
+	gaz2.Run()
+	time.Sleep(1 * time.Second)
+	fmt.Println("gaz2 started")
+	gaz2.Shutdown()
+	fmt.Println("gaz2 stopped")
+
+}
+
 func TestStreamLazy(t *testing.T) {
 	g, addr, shutdown := newGaz()
 	g.InitLogs("debug")

--- a/stream_test.go
+++ b/stream_test.go
@@ -27,7 +27,7 @@ func assertEquals(t *testing.T, got, expected, comment string) {
 }
 
 func TestStreamLazy(t *testing.T) {
-	g := New(WithConfigPath("testConfig"), WithMockedServiceDiscovery())
+	g := New(WithServiceName("test"), WithMockedServiceDiscovery())
 	defer g.Shutdown()
 	<-g.Run()
 
@@ -53,7 +53,7 @@ func TestStreamLazy(t *testing.T) {
 }
 
 func TestStreamEvents(t *testing.T) {
-	g := New(WithConfigPath("testConfig"), WithMockedServiceDiscovery())
+	g := New(WithServiceName("test"), WithMockedServiceDiscovery())
 	defer g.Shutdown()
 	<-g.Run()
 
@@ -97,7 +97,7 @@ func TestStreamEvents(t *testing.T) {
 }
 
 func TestMultipleConsumers(t *testing.T) {
-	g := New(WithConfigPath("testConfig"), WithMockedServiceDiscovery())
+	g := New(WithServiceName("test"), WithMockedServiceDiscovery())
 	defer g.Shutdown()
 	<-g.Run()
 
@@ -133,7 +133,7 @@ func TestMultipleConsumers(t *testing.T) {
 
 func TestProducerReconnect(t *testing.T) {
 	mock, sdOption := NewMockedServiceDiscovery()
-	g := New(WithConfigPath("testConfig"), sdOption)
+	g := New(WithServiceName("test"), sdOption)
 	<-g.Run()
 
 	streamName := "testaa"
@@ -162,7 +162,7 @@ func TestProducerReconnect(t *testing.T) {
 	// wait a bit to be sure the consumer has seen it
 	time.Sleep(time.Second)
 
-	g = New(WithConfigPath("testConfig"))
+	g = New(WithServiceName("test"))
 	<-g.Run()
 	mock.UpdateGaz(g)
 	defer g.Shutdown()

--- a/testConfig/application.properties
+++ b/testConfig/application.properties
@@ -1,1 +1,0 @@
-service.name=gorillazServiceTest

--- a/testConfig/application.properties
+++ b/testConfig/application.properties
@@ -1,0 +1,1 @@
+service.name=gorillazServiceTest

--- a/trace.go
+++ b/trace.go
@@ -5,7 +5,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	zlog "github.com/opentracing/opentracing-go/log"
 	"github.com/skysoft-atm/zipkin-go-light-opentracing"
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"log"
 )
@@ -30,13 +29,13 @@ func (g *Gaz) InitTracingFromConfig() {
 		collectorUrl, err = g.resolveZipkinUrlFromServiceDiscovery()
 		if err != nil {
 			Log.Info("Error while resolving zipkin from service discovery", zap.Error(err))
-			collectorUrl = viper.GetString("tracing.collector.url")
+			collectorUrl = g.Viper.GetString("tracing.collector.url")
 		} else if err != nil {
 			Log.Info("No zipkin instance found in service discovery")
-			collectorUrl = viper.GetString("tracing.collector.url")
+			collectorUrl = g.Viper.GetString("tracing.collector.url")
 		}
 	} else {
-		collectorUrl = viper.GetString("tracing.collector.url")
+		collectorUrl = g.Viper.GetString("tracing.collector.url")
 	}
 
 	g.InitTracing(


### PR DESCRIPTION
This is a first version of the modified gorillaz to remove the global state.
Prometheus and Viper are now embedded in the gaz object, this means that we should no longer call viper directly with a viper.Something method, and that we should not use the promauto package to register metrics.
I also removed the manual config file parsing since Viper is able to handle it natively.
With these changes we should be able to start gorillaz for each test, and stop it at the end of the test.
The only global state that remains are the 2 loggers, but I think we can live with that for now.
I also added a mocked service discovery, that will resolve everything to the local gRPC server.

I modified the stream_test to make use of the new functionalities.