### PR TITLE
SNG-57: export Go runtime metrics and process metrics

### DIFF
--- a/gorillaz.go
+++ b/gorillaz.go
@@ -111,6 +111,12 @@ func WithGrpcServerOptions(o ...grpc.ServerOption) Option {
 func New(options ...GazOption) *Gaz {
 	GracefulStop()
 	gaz := Gaz{Router: mux.NewRouter(), isReady: new(int32), isLive: new(int32), Viper: viper.New(), prometheusRegistry: prometheus.NewRegistry()}
+
+	// expose Go metrics and process metrics as Prometheus DefaultRegistry would
+	// https://github.com/prometheus/client_golang/blob/v1.1.0/prometheus/registry.go#L60
+	gaz.prometheusRegistry.Register(prometheus.NewGoCollector())
+	gaz.prometheusRegistry.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+
 	gaz.httpSrv = &http.Server{Handler: gaz.Router}
 	gaz.streamConsumers = &streamConsumerRegistry{
 		g:                 &gaz,


### PR DESCRIPTION
For details: [SNG-57](https://skysoft-atm.atlassian.net/browse/SNG-57?atlOrigin=eyJpIjoiOWU4ZTA3ZGE2YzJhNDE1ZmFkNTFkZDU0NTIxNTQ4ZWMiLCJwIjoiaiJ9)

Note: as this is a bugfix, the PR is created from the master branch