### PR TITLE
stream_consumer.go: cancel the ctx passed to client.Stream 

### DIFF
--- a/stream_consumer.go
+++ b/stream_consumer.go
@@ -267,8 +267,10 @@ func (se *streamEndpoint) reconnectWhileNotStopped(c *consumer, streamName strin
 		if config.UseGzip {
 			callOpts = append(callOpts, grpc.UseCompressor(gzip.Name))
 		}
-		st, err := client.Stream(context.Background(), req, callOpts...)
+		ctx, cancel := context.WithCancel(context.Background())
+		st, err := client.Stream(ctx, req, callOpts...)
 		if err != nil {
+			cancel()
 			Log.Warn("Error while creating stream", zap.String("stream", streamName), zap.Error(err))
 			continue
 		}
@@ -320,7 +322,7 @@ func (se *streamEndpoint) reconnectWhileNotStopped(c *consumer, streamName strin
 		if config.OnDisconnected != nil {
 			config.OnDisconnected(streamName)
 		}
-
+		cancel()
 	}
 }
 


### PR DESCRIPTION
when the stream is not really connected

there is a leak in one application, the logs show many Stream created but not connected
gorillaz CreateConsumer will call again stream.NewStreamClient, which calls https://github.com/grpc/grpc-go/blob/v1.22.1/stream.go#L142
as we don't close the context, nor close properly the ClientStream, there is a leak of goroutine
the proposed fix uses context cancel function to close force ClientStream to get closed during the loop