### PR TITLE
Feature/disconnect on backpressure

### DIFF
--- a/getAndWatch_stream_provider.go
+++ b/getAndWatch_stream_provider.go
@@ -30,6 +30,7 @@ type GetAndWatchConfig struct {
 	SubscriberInputBufferLen int                     // SubscriberInputBufferLen is the size of the channel used to forward events to each client. (default: 256)
 	OnBackPressure           func(streamName string) // OnBackPressure is the function called when a customer cannot consume fast enough and event are dropped. (default: log)
 	Ttl                      time.Duration
+	DisconnectOnBackpressure bool // Disconnect consumer if not able to consume fast enough
 }
 
 func defaultGetAndWatchConfig() *GetAndWatchConfig {
@@ -107,6 +108,9 @@ func (p *GetAndWatchStreamProvider) sendLoop(strm grpc.ServerStream, peer Peer) 
 			p.config.OnBackPressure(streamName)
 			p.metrics.backPressureCounter.Inc()
 		})
+		if p.config.DisconnectOnBackpressure {
+			config.DisconnectOnBackpressure()
+		}
 		return nil
 	})
 	defer broadcaster.Unregister(streamCh)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/zap v1.10.0
-	google.golang.org/grpc v1.26.0
+	google.golang.org/grpc v1.25.1
 )
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.0
 	github.com/gorilla/websocket v1.4.0
+	github.com/magiconair/properties v1.8.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/zap v1.10.0
-	google.golang.org/grpc v1.25.1
+	google.golang.org/grpc v1.26.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -238,6 +239,8 @@ google.golang.org/grpc v1.21.0 h1:G+97AoqBnmZIT91cLG/EkCoK9NSelj64P8bOHHNmGn0=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
+google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/gorillaz.go
+++ b/gorillaz.go
@@ -342,12 +342,9 @@ func (g *Gaz) GrpcDialService(serviceName string, opts ...grpc.DialOption) (*grp
 }
 
 func (g *Gaz) GrpcDial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	clientKeepAlive := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-		Time:                15 * time.Second,
-		PermitWithoutStream: true,
-	})
 	options := make([]grpc.DialOption, len(opts)+3)
 	options[0] = grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`)
+
 	options[1] = grpc.WithConnectParams(grpc.ConnectParams{
 		MinConnectTimeout: 2 * time.Second,
 		Backoff: backoff.Config{
@@ -357,7 +354,10 @@ func (g *Gaz) GrpcDial(target string, opts ...grpc.DialOption) (*grpc.ClientConn
 			MaxDelay:   5 * time.Second,
 		},
 	})
-	options[2] = clientKeepAlive
+	options[2] = grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                15 * time.Second,
+		PermitWithoutStream: true,
+	})
 	for i, o := range opts {
 		options[3+i] = o
 	}

--- a/gorillaz.go
+++ b/gorillaz.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
@@ -347,7 +348,15 @@ func (g *Gaz) GrpcDial(target string, opts ...grpc.DialOption) (*grpc.ClientConn
 	})
 	options := make([]grpc.DialOption, len(opts)+3)
 	options[0] = grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`)
-	options[1] = grpc.WithBackoffMaxDelay(5 * time.Second)
+	options[1] = grpc.WithConnectParams(grpc.ConnectParams{
+		MinConnectTimeout: 2 * time.Second,
+		Backoff: backoff.Config{
+			Multiplier: 1.6,
+			Jitter:     0.2,
+			BaseDelay:  200 * time.Millisecond,
+			MaxDelay:   5 * time.Second,
+		},
+	})
 	options[2] = clientKeepAlive
 	for i, o := range opts {
 		options[3+i] = o

--- a/mux/broadcaster.go
+++ b/mux/broadcaster.go
@@ -21,8 +21,7 @@ type Broadcaster struct {
 	unreg    chan unregistration
 	outputs  map[chan<- interface{}]ConsumerConfig
 	*BroadcasterConfig
-	subscriberCount uint64
-	closed          uint32
+	closed uint32
 }
 
 // Register a new channel to receive broadcasts
@@ -97,39 +96,47 @@ func (b *Broadcaster) broadcast(m interface{}) {
 func (b *Broadcaster) run() {
 	for {
 		// if lazy, if there is no more subscriber, do not consume any value until there is at least 1 subscriber
-		for !b.eagerBroadcast && b.subscriberCount == 0 {
+		if !b.eagerBroadcast && len(b.outputs) == 0 {
 			select {
+			case u := <-b.unreg:
+				// there is currently no registration
+				u.done <- true
 			case r := <-b.reg:
 				b.addSubscriber(r)
 			case closed := <-b.closeReq:
 				closed <- true
 				return
 			}
-		}
-		select {
-		case closed := <-b.closeReq:
-			close(b.input)
-			// if there are still messages to broadcast, do it
-			for m := range b.input {
+		} else {
+			select {
+			case closed := <-b.closeReq:
+				close(b.input)
+				if len(b.outputs) == 0 {
+					closed <- true
+					return
+				}
+				// if there are still messages to broadcast, do it
+				for m := range b.input {
+					b.broadcast(m)
+				}
+				// close all subscribers
+				for sub := range b.outputs {
+					close(sub)
+				}
+				// cleanup b.outputs
+				for sub := range b.outputs {
+					delete(b.outputs, sub)
+				}
+				closed <- true
+				return
+			case r := <-b.reg:
+				b.addSubscriber(r)
+			case u := <-b.unreg:
+				b.unregister(u.channel)
+				u.done <- true
+			case m := <-b.input:
 				b.broadcast(m)
 			}
-			// close all subscribers
-			for sub := range b.outputs {
-				close(sub)
-			}
-			// cleanup b.outputs
-			for sub := range b.outputs {
-				delete(b.outputs, sub)
-			}
-			closed <- true
-			return
-		case r := <-b.reg:
-			b.addSubscriber(r)
-		case u := <-b.unreg:
-			b.unregister(u.channel)
-			u.done <- true
-		case m := <-b.input:
-			b.broadcast(m)
 		}
 	}
 }
@@ -139,13 +146,11 @@ func (b *Broadcaster) unregister(ch chan<- interface{}) {
 	if _, ok := b.outputs[ch]; ok {
 		delete(b.outputs, ch)
 		close(ch)
-		b.subscriberCount--
 	}
 }
 
 func (b *Broadcaster) addSubscriber(r registration) {
 	b.outputs[r.consumer.channel] = r.consumer.config
-	b.subscriberCount++
 	r.done <- true
 }
 

--- a/mux/broadcaster_test.go
+++ b/mux/broadcaster_test.go
@@ -124,6 +124,73 @@ func TestProducerDropsMessageOnBackpressure(t *testing.T) {
 	}
 }
 
+func TestDisconnectOnBackPressure(t *testing.T) {
+	b := NewNonBlockingBroadcaster(0)
+	ch1 := make(chan interface{}, 1)
+	ch2 := make(chan interface{}, 1)
+
+	b.Register(ch1, DisconnectOnBackPressure())
+	b.Register(ch2)
+
+	b.SubmitBlocking(1)
+
+	// ch1  and ch2 should be open with 1 element
+	found, i, open := consume(ch1)
+	assert.Equal(t, found, true)
+	assert.Equal(t, i, 1)
+	assert.Equal(t, open, true)
+
+	found, i, open = consume(ch2)
+	assert.Equal(t, found, true)
+	assert.Equal(t, i, 1)
+	assert.Equal(t, open, true)
+
+	// now ch1 and ch2 should be empty
+	found, _, open = consume(ch1)
+	assert.Equal(t, found, false)
+	assert.Equal(t, open, true)
+
+	found, _, open = consume(ch2)
+	assert.Equal(t, found, false)
+	assert.Equal(t, open, true)
+
+	// put back 2 elements inside
+	b.SubmitBlocking(3)
+	b.SubmitBlocking(4)
+
+	// there is place for only 1 element in ch1 and ch2
+	// ch1 has DisconnectOnBackpressure, so the channel should be closed
+	found, i, open = consume(ch1)
+	assert.Equal(t, true, found)
+	assert.Equal(t, 3, i)
+	assert.Equal(t, true, open)
+
+	found, i, open = consume(ch1)
+	assert.Equal(t, true, found)
+	assert.Equal(t, nil, i)
+	assert.Equal(t, false, open)
+
+	// ch2 does not have DisconnectOnBackpressure, so it should still be open, with 1 element inside
+	found, i, open = consume(ch2)
+	assert.Equal(t, true, found)
+	assert.Equal(t, 3, i)
+	assert.Equal(t, true, open)
+
+	found, i, open = consume(ch2)
+	assert.Equal(t, false, found)
+	assert.Equal(t, nil, i)
+	assert.Equal(t, true, open)
+}
+
+func consume(c chan interface{}) (found bool, value interface{}, open bool) {
+	select {
+	case v, ok := <-c:
+		return true, v, ok
+	case <-time.After(500 * time.Millisecond):
+		return false, nil, true
+	}
+}
+
 func TestNoBackpressureOnProducerWithEagerBroadcast(t *testing.T) {
 	b := NewNonBlockingBroadcaster(0)
 	var sent = make(chan bool, 1)

--- a/mux/common.go
+++ b/mux/common.go
@@ -28,7 +28,8 @@ type BroadcasterConfig struct {
 }
 
 type ConsumerConfig struct {
-	onBackpressure func(value interface{})
+	onBackpressure           func(value interface{})
+	disconnectOnBackpressure bool
 }
 
 type BroadcasterOptionFunc func(*BroadcasterConfig)
@@ -37,6 +38,24 @@ type ConsumerOptionFunc func(*ConsumerConfig) error
 
 func (s *ConsumerConfig) OnBackpressure(onBackpressure func(value interface{})) {
 	s.onBackpressure = onBackpressure
+}
+
+func (s *ConsumerConfig) DisconnectOnBackpressure() {
+	s.disconnectOnBackpressure = true
+}
+
+func WithOnBackPressure(onBackpressure func(value interface{})) ConsumerOptionFunc {
+	return func(c *ConsumerConfig) error {
+		c.onBackpressure = onBackpressure
+		return nil
+	}
+}
+
+func DisconnectOnBackPressure() ConsumerOptionFunc {
+	return func(c *ConsumerConfig) error {
+		c.disconnectOnBackpressure = true
+		return nil
+	}
 }
 
 // Defines an action that will be done once the value has been broadcasted.

--- a/mux/common.go
+++ b/mux/common.go
@@ -4,12 +4,12 @@ import "time"
 
 type registration struct {
 	consumer consumer
-	done     chan<- bool
+	done     chan<- struct{}
 }
 
 type unregistration struct {
 	channel chan<- interface{}
-	done    chan<- bool
+	done    chan<- struct{}
 }
 
 type consumer struct {

--- a/sd.go
+++ b/sd.go
@@ -38,7 +38,7 @@ type gorillazResolverBuilder struct {
 	gaz *Gaz
 }
 
-func (g *gorillazResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+func (g *gorillazResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	var result resolver.Resolver
 
 	if strings.HasPrefix(target.Endpoint, SdPrefix) {
@@ -118,7 +118,7 @@ func (r *serviceDiscoveryResolver) sendUpdate() {
 	r.cc.UpdateState(resolver.State{Addresses: addrs})
 }
 
-func (*serviceDiscoveryResolver) ResolveNow(o resolver.ResolveNowOption) {}
+func (*serviceDiscoveryResolver) ResolveNow(o resolver.ResolveNowOptions) {}
 
 func (r *serviceDiscoveryResolver) Close() {
 	select {
@@ -139,8 +139,8 @@ type gorillazDefaultResolver struct {
 func (r *gorillazDefaultResolver) start() {
 	r.cc.UpdateState(resolver.State{Addresses: r.addresses})
 }
-func (*gorillazDefaultResolver) ResolveNow(o resolver.ResolveNowOption) {}
-func (*gorillazDefaultResolver) Close()                                 {}
+func (*gorillazDefaultResolver) ResolveNow(o resolver.ResolveNowOptions) {}
+func (*gorillazDefaultResolver) Close()                                  {}
 
 func (g *Gaz) Register(d *ServiceDefinition) (RegistrationHandle, error) {
 	if g.ServiceDiscovery == nil {

--- a/stream_consumer.go
+++ b/stream_consumer.go
@@ -239,7 +239,7 @@ func (g *Gaz) newStreamEndpoint(endpoints []string, opts ...StreamEndpointConfig
 		grpc.WithConnectParams(grpc.ConnectParams{
 			MinConnectTimeout: 2 * time.Second,
 			Backoff: backoff.Config{
-				BaseDelay:  500 * time.Millisecond,
+				BaseDelay:  100 * time.Millisecond,
 				Multiplier: 1.6,
 				MaxDelay:   config.backoffMaxDelay,
 				Jitter:     0.2,

--- a/stream_consumer.go
+++ b/stream_consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/skysoft-atm/gorillaz/stream"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/encoding/gzip"
@@ -235,7 +236,15 @@ func (g *Gaz) newStreamEndpoint(endpoints []string, opts ...StreamEndpointConfig
 	target := strings.Join(endpoints, ",")
 	conn, err := g.GrpcDial(target, grpc.WithInsecure(),
 		grpc.WithDefaultCallOptions(grpc.ForceCodec(&gogoCodec{})),
-		grpc.WithBackoffMaxDelay(config.backoffMaxDelay),
+		grpc.WithConnectParams(grpc.ConnectParams{
+			MinConnectTimeout: 2 * time.Second,
+			Backoff: backoff.Config{
+				BaseDelay:  500 * time.Millisecond,
+				Multiplier: 1.6,
+				MaxDelay:   config.backoffMaxDelay,
+				Jitter:     0.2,
+			},
+		}),
 	)
 
 	if err != nil {

--- a/stream_provider.go
+++ b/stream_provider.go
@@ -168,8 +168,8 @@ func (p *StreamProvider) Submit(evt *stream.Event) {
 	p.metrics.sentCounter.Inc()
 	p.metrics.lastEventTimestamp.SetToCurrentTime()
 
-	b, err := proto.Marshal(streamEvent)
-	if err != nil {
+	b, err2 := proto.Marshal(streamEvent)
+	if err2 != nil {
 		Log.Error("error while marshaling stream.StreamEvent, cannot send event", zap.Error(err))
 		return
 	}

--- a/stream_provider.go
+++ b/stream_provider.go
@@ -128,6 +128,7 @@ type ProviderConfig struct {
 	SubscriberInputBufferLen int                     // SubscriberInputBufferLen is the size of the channel used to forward events to each client. (default: 256)
 	OnBackPressure           func(streamName string) // OnBackPressure is the function called when a customer cannot consume fast enough and event are dropped. (default: log)
 	LazyBroadcast            bool                    // if lazy broadcaster, then the provider doesn't consume messages as long as there is no consumer
+	DisconnectOnBackPressure bool                    // if DisconnectOnBackpressure, in case of backpressure, disconnect the consumer
 }
 
 func defaultProviderConfig() *ProviderConfig {
@@ -201,6 +202,9 @@ func (p *StreamProvider) sendLoop(strm grpc.ServerStream, peer Peer) {
 			p.config.OnBackPressure(streamName)
 			p.metrics.backPressureCounter.Inc()
 		})
+		if p.config.DisconnectOnBackPressure {
+			config.DisconnectOnBackpressure()
+		}
 		return nil
 	})
 

--- a/stream_registry.go
+++ b/stream_registry.go
@@ -27,7 +27,7 @@ type StreamDefinition struct {
 type provider interface {
 	close()
 	streamDefinition() *StreamDefinition
-	sendLoop(strm grpc.ServerStream, peer Peer)
+	sendLoop(strm grpc.ServerStream, peer Peer) error
 	streamType() stream.StreamType
 	sendHelloMessage(strm grpc.ServerStream, peer Peer) error
 }
@@ -137,8 +137,7 @@ func (sr *streamRegistry) publishOnStream(np StreamRequest, strm grpc.ServerStre
 			return err
 		}
 	}
-	provider.sendLoop(strm, peer)
-	return nil
+	return provider.sendLoop(strm, peer)
 }
 
 func getPeer(strm grpc.ServerStream, np StreamRequest) Peer {

--- a/stream_test.go
+++ b/stream_test.go
@@ -89,10 +89,6 @@ func TestStreamEvents(t *testing.T) {
 		Value: []byte("testooValue"),
 	}
 
-	// TODO: not great to sleep here, but connected just means we were able to connect the streaming provider
-	// it doesn't mean the registration is done on the server side, so we must wait for the registration to be successful
-	time.Sleep(time.Second * 1)
-
 	provider1.Submit(evt1)
 	provider2.Submit(evt2)
 


### PR DESCRIPTION
feature:
stream provider can now be configured to kick out a consumer if it's too slow

This can be useful to prevent consumers from not knowing they are loosing messages.

On top of this, this PR fixes deprecation warnings for gRPC 1.26.0
@matgabriel please double check the gRPC connection parameters. I don't like the fact that we have plenty of default values, but I wanted to keep the same behavior as we have right now.

I started to write a unit test with 2 providers and 1 consumer, showing that once the 1st provider was having issues forwarding messages to the consumer, then the backpressure would be applied and the consumer would reconnect to the second provider.
I had to remove this test for 2 reasons:
+ the gRPC round_robin balancer doesn't always return the address of the second provider, so I was reconnected to the first provider
+ the internal buffering of gRPC streaming of 64k makes it really hard to hit backpressure in a predictable way.