### PR TITLE
Feature/disconnect on backpressure client side

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -392,7 +392,7 @@ func TestDisconnectOnBackpressure(t *testing.T) {
 	}
 	defer consumer.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	backPressureOnProvider := false


### PR DESCRIPTION
Remove the disconnect slow consumer on producer side, consumers should be able to ask how they want to consume events.

add the possibility to consumer to provide a header asking for disconnection if they are consuming to slowly

Add a SubmitNonBlocking on the stream provider so we have a mechanism in case of burst of data to discard events